### PR TITLE
Remove IndentLine plugin

### DIFF
--- a/files/neovim_config
+++ b/files/neovim_config
@@ -47,7 +47,6 @@ set hidden
 set autoread
 au FocusGained * :checktime
 autocmd FileType * setlocal formatoptions-=c formatoptions-=r formatoptions-=o
-let g:tex_conceal = ""
 
 call plug#begin('/usr/share/nvim/runtime/plugged')
 Plug 'itchyny/lightline.vim'
@@ -62,7 +61,6 @@ Plug 'scrooloose/nerdtree'
 Plug 'scrooloose/syntastic'
 Plug 'kshenoy/vim-signature'
 Plug 'joshdick/onedark.vim'
-Plug 'yggdroot/indentline'
 Plug 'neoclide/coc.nvim', {'tag': '*', 'do': './install.sh'}
 Plug 'farmergreg/vim-lastplace'
 Plug 'rhysd/vim-clang-format'


### PR DESCRIPTION
Remove IndentLine plugin so conceallevel can be set to 0.
Also remove g:tex_conceal as it is only necessary if tex-conceal plugin is installed.